### PR TITLE
fix: remove error formats

### DIFF
--- a/src/main/java/com/onixbyte/calendar/property/DateTimeEnd.java
+++ b/src/main/java/com/onixbyte/calendar/property/DateTimeEnd.java
@@ -200,7 +200,7 @@ public final class DateTimeEnd implements ComponentProperty, DateTimeProperty {
     @Override
     public String formatted() {
         var builder = new StringBuilder();
-        builder.append("{@code DTEND}");
+        builder.append("DTEND");
 
         var paramAppender = ParamAppender.of(builder);
 


### PR DESCRIPTION
This pull request includes a minor update to the `formatted` method in the `DateTimeEnd` class. The change removes the use of `{@code}` tags in the appended string, simplifying the output.

* [`src/main/java/com/onixbyte/calendar/property/DateTimeEnd.java`](diffhunk://#diff-e78c84f1165eddafdacc89b69c2bcd50d88990e9ee7c8d8a3b239ddd9eecd4c4L203-R203): Updated the `formatted` method to append "DTEND" directly instead of using the `{@code}` tag.