### PR TITLE
fix

### DIFF
--- a/.github/workflows/package-and-publish.yml
+++ b/.github/workflows/package-and-publish.yml
@@ -58,7 +58,7 @@ jobs:
         run: ./gradlew build -PartefactVersion=${{ github.event.release.tag_name }}
 
       - name: List Output Items
-        run: ls -l ./**/build/libs
+        run: ls -l **/build/libs
 
       - name: Publish to Maven Central
         run: ./gradlew publish

--- a/src/main/java/com/onixbyte/calendar/component/Journal.java
+++ b/src/main/java/com/onixbyte/calendar/component/Journal.java
@@ -410,6 +410,12 @@ public final class Journal implements ComponentProperty {
         private List<RequestStatus> requestStatuses;
 
         /**
+         * Private constructor prevent from being instantiated from non-standard operations.
+         */
+        private JournalBuilder() {
+        }
+
+        /**
          * Sets the date and time stamp for the journal entry.
          *
          * @param stamp the date and time stamp when the journal entry was created


### PR DESCRIPTION
This pull request includes changes to streamline workflow configuration and improve code safety in the `JournalBuilder` class. The most important changes include simplifying a file listing command in the GitHub Actions workflow and adding a private constructor to the `JournalBuilder` class to prevent unintended instantiation.

### Workflow configuration improvements:
* [`.github/workflows/package-and-publish.yml`](diffhunk://#diff-30f8342ef0691769a4eb0bce8bdfcd97c08738118eca2df863e8525992157611L61-R61): Simplified the `ls` command in the "List Output Items" step by removing the redundant `./` prefix, making the command cleaner and easier to read.

### Code safety enhancements:
* [`src/main/java/com/onixbyte/calendar/component/Journal.java`](diffhunk://#diff-c80e430e3f62c99d7f3c9f33ad62caee04a206b133074ef0c6ad36752cf415e5R412-R417): Added a private constructor to the `JournalBuilder` class to prevent it from being instantiated outside of its intended usage, ensuring better encapsulation and adherence to design patterns.